### PR TITLE
Fix the build on MSVC

### DIFF
--- a/interpreter/cling/cmake/modules/CMakeLists.txt
+++ b/interpreter/cling/cmake/modules/CMakeLists.txt
@@ -53,8 +53,7 @@ set(CLING_CONFIG_CMAKE_DIR)
 set(CLING_CONFIG_EXPORTS_FILE)
 
 if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-  get_property(cling_has_exports GLOBAL PROPERTY CLING_HAS_EXPORTS)
-  if(cling_has_exports)
+  if(CLING_EXPORTS)
     install(EXPORT ClingTargets DESTINATION ${CLING_INSTALL_PACKAGE_DIR}
             COMPONENT cling-cmake-exports)
   endif()

--- a/interpreter/cling/tools/driver/CMakeLists.txt
+++ b/interpreter/cling/tools/driver/CMakeLists.txt
@@ -57,7 +57,7 @@ if(MSVC)
     _Init_thread_footer _Init_thread_header _tls_index
   )
 
-  if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64")
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     # new/delete variants needed when linking to static msvc runtime (esp. Debug)
     set(cling_exports ${cling_exports}
       ??2@YAPEAX_K@Z


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

The `CMAKE_GENERATOR_PLATFORM` is only set when manually specified with `cmake -A <platform>`. The `CMAKE_SIZEOF_VOID_P` variable is set automatically by the `project()` call (and it's used elsewhere in the code).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

Closes https://github.com/root-project/cling/issues/454